### PR TITLE
CDTA-1148/Remove-broken-links

### DIFF
--- a/public/documentation/customer-support.html
+++ b/public/documentation/customer-support.html
@@ -15,16 +15,6 @@
 
     <link href="/guides/common-transit-convention-traders-service-guide/stylesheets/print.css" rel="stylesheet" media="print" />
     <script src="/guides/common-transit-convention-traders-service-guide/javascripts/application.js"></script>
-
-      <meta property="og:image" content="docs.developer.service.hmrc.gov.uk/images/govuk-large.png" />
-      <meta property="og:site_name" content="HMRC Developer Hub" />
-      <meta property="og:title" content="Customer support model | VAT (MTD) End-to-End Service Guide" />
-      <meta property="og:type" content="object" />
-      <meta property="og:url" content="docs.developer.service.hmrc.gov.uk/guides/common-transit-convention-traders-service-guide/documentation/customer-support.html" />
-      <meta property="twitter:card" content="summary" />
-      <meta property="twitter:image" content="docs.developer.service.hmrc.gov.uk/images/govuk-large.png" />
-      <meta property="twitter:title" content="Customer support model | VAT (MTD) End-to-End Service Guide | HMRC Developer Hub" />
-      <meta property="twitter:url" content="docs.developer.service.hmrc.gov.uk/guides/common-transit-convention-traders-service-guide/documentation/customer-support.html" />
   </head>
 
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -15,15 +15,6 @@
 
     <link href="/guides/common-transit-convention-traders-service-guide/stylesheets/print.css" rel="stylesheet" media="print" />
     <script src="/guides/common-transit-convention-traders-service-guide/javascripts/application.js"></script>
-
-      <meta property="og:image" content="docs.developer.service.hmrc.gov.uk/images/govuk-large.png" />
-      <meta property="og:site_name" content="HMRC Developer Hub" />
-      <meta property="og:type" content="object" />
-      <meta property="og:url" content="docs.developer.service.hmrc.gov.uk/guides/common-transit-convention-traders-service-guide/" />
-      <meta property="twitter:card" content="summary" />
-      <meta property="twitter:image" content="docs.developer.service.hmrc.gov.uk/images/govuk-large.png" />
-      <meta property="twitter:title" content="HMRC Developer Hub" />
-      <meta property="twitter:url" content="docs.developer.service.hmrc.gov.uk/guides/common-transit-convention-traders-service-guide/" />
   </head>
 
   <body>


### PR DESCRIPTION
# Remove broken links

Removal of broken meta tag links for twitter and facebook

[Ticket](https://jira.tools.tax.service.gov.uk/browse/CTDA-1148)