### PR TITLE
Removed LDS exemption

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,5 +1,1 @@
-leakDetectionExemptions:
-  - ruleId: 'ip_addresses'
-    filePaths:
-      - '/Gemfile.lock'
 repoVisibility: public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71


### PR DESCRIPTION
Removed the LDS exemption for IP addresses in the gemfile.lock file as there are no IP addresses in that file.